### PR TITLE
fix(ui): modal visibility & z-index; prevent nav on add buttons; correct /transactions link

### DIFF
--- a/src/app/accounts/page.js
+++ b/src/app/accounts/page.js
@@ -119,6 +119,7 @@ export default function AccountsPage() {
         title="Accounts"
         actions={
           <button
+            type="button"
             onClick={() => {
               setEditingAccount(null);
               setIsModalOpen(true);
@@ -155,7 +156,7 @@ export default function AccountsPage() {
       </Card>
 
       <Modal
-        isOpen={isModalOpen}
+        open={isModalOpen}
         onClose={() => {
           setIsModalOpen(false);
           setEditingAccount(null);

--- a/src/app/documents/page.js
+++ b/src/app/documents/page.js
@@ -122,6 +122,7 @@ export default function DocumentsPage() {
         title="Documents"
         actions={
           <button
+            type="button"
             onClick={() => setIsUploadModalOpen(true)}
             className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-lg shadow-sm text-white bg-sky-400 hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-0"
           >
@@ -143,6 +144,7 @@ export default function DocumentsPage() {
               <div className="text-center py-8">
                 <p className="text-slate-400 mb-4">No documents found</p>
                 <button
+                  type="button"
                   onClick={() => setIsUploadModalOpen(true)}
                   className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-lg shadow-sm text-white bg-sky-400 hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-0"
                 >
@@ -155,7 +157,7 @@ export default function DocumentsPage() {
       </Card>
 
       <Modal
-        isOpen={isUploadModalOpen}
+        open={isUploadModalOpen}
         onClose={() => setIsUploadModalOpen(false)}
         title="Upload Document"
       >

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
+import AddTransactionButton from '@/components/AddTransactionButton';
 import { formatINR } from '@/lib/format';
 import { api } from '@/lib/fetcher';
 import Card from '@/components/Card';
@@ -69,14 +70,7 @@ function Dashboard() {
     <div>
       <PageHeader 
         title="Dashboard"
-        actions={
-          <Link 
-            href="/transactions/new" 
-            className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-lg shadow-sm text-white bg-sky-400 hover:bg-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-400 focus:ring-offset-0"
-          >
-            Add Transaction
-          </Link>
-        }
+        actions={<AddTransactionButton />}
       />
 
       <div className="grid grid-cols-1 gap-6 mt-6 sm:grid-cols-2 lg:grid-cols-3">

--- a/src/app/transactions/page.js
+++ b/src/app/transactions/page.js
@@ -162,6 +162,7 @@ export default function TransactionsPage() {
         title="Transactions"
         actions={
           <button
+            type="button"
             onClick={() => {
               setEditingTransaction(null);
               setIsModalOpen(true);
@@ -253,7 +254,7 @@ export default function TransactionsPage() {
       </Card>
 
       <Modal
-        isOpen={isModalOpen}
+        open={isModalOpen}
         onClose={() => {
           setIsModalOpen(false);
           setEditingTransaction(null);

--- a/src/components/AddTransactionButton.js
+++ b/src/components/AddTransactionButton.js
@@ -1,0 +1,26 @@
+"use client";
+
+import { useState } from "react";
+import Modal from "@/components/Modal";
+import TransactionForm from "@/components/Forms/TransactionForm";
+
+export default function AddTransactionButton() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="rounded-lg px-4 py-2 bg-sky-500 hover:bg-sky-600 text-white"
+      >
+        Add Transaction
+      </button>
+      <Modal open={open} onClose={() => setOpen(false)} title="Add New Transaction">
+        <TransactionForm
+          onSuccess={() => setOpen(false)}
+          onCancel={() => setOpen(false)}
+        />
+      </Modal>
+    </>
+  );
+}

--- a/src/components/Forms/AccountForm.js
+++ b/src/components/Forms/AccountForm.js
@@ -61,7 +61,7 @@ export default function AccountForm({ initialData = {}, onSuccess, onCancel }) {
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       <div>
-        <label htmlFor="name" className="block text-sm font-medium text-slate-400">
+        <label htmlFor="name" className="block text-sm font-medium text-slate-300">
           Account Name
         </label>
         <input
@@ -70,13 +70,13 @@ export default function AccountForm({ initialData = {}, onSuccess, onCancel }) {
           name="name"
           value={formData.name}
           onChange={handleChange}
-          className="mt-1 block w-full rounded-md bg-slate-900 border border-slate-700 text-slate-50 placeholder-slate-400 shadow-sm focus:border-sky-400 focus:ring-sky-400 sm:text-sm"
+          className="mt-1 block w-full rounded-md bg-slate-900 text-slate-100 placeholder-slate-500 border border-slate-700 shadow-sm focus:border-sky-400 sm:text-sm"
           required
         />
       </div>
 
       <div>
-        <label htmlFor="type" className="block text-sm font-medium text-slate-400">
+        <label htmlFor="type" className="block text-sm font-medium text-slate-300">
           Account Type
         </label>
         <select
@@ -84,7 +84,7 @@ export default function AccountForm({ initialData = {}, onSuccess, onCancel }) {
           name="type"
           value={formData.type}
           onChange={handleChange}
-          className="mt-1 block w-full rounded-md bg-slate-900 border border-slate-700 text-slate-50 py-2 pl-3 pr-10 text-base focus:border-sky-400 focus:outline-none focus:ring-sky-400 sm:text-sm"
+          className="mt-1 block w-full rounded-md bg-slate-900 text-slate-100 placeholder-slate-500 border border-slate-700 py-2 pl-3 pr-10 text-base focus:border-sky-400 sm:text-sm"
           required
         >
           {accountTypes.map((type) => (
@@ -96,12 +96,12 @@ export default function AccountForm({ initialData = {}, onSuccess, onCancel }) {
       </div>
 
       <div>
-        <label htmlFor="balance" className="block text-sm font-medium text-slate-400">
+        <label htmlFor="balance" className="block text-sm font-medium text-slate-300">
           Current Balance
         </label>
         <div className="mt-1 relative rounded-md shadow-sm">
           <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-            <span className="text-slate-400 sm:text-sm">₹</span>
+            <span className="text-slate-300 sm:text-sm">₹</span>
           </div>
           <input
             type="number"
@@ -110,7 +110,7 @@ export default function AccountForm({ initialData = {}, onSuccess, onCancel }) {
             name="balance"
             value={formData.balance}
             onChange={handleChange}
-            className="pl-7 block w-full rounded-md bg-slate-900 border border-slate-700 text-slate-50 placeholder-slate-400 shadow-sm focus:border-sky-400 focus:ring-sky-400 sm:text-sm"
+            className="pl-7 block w-full rounded-md bg-slate-900 text-slate-100 placeholder-slate-500 border border-slate-700 shadow-sm focus:border-sky-400 sm:text-sm"
             required
           />
         </div>

--- a/src/components/Forms/DocumentUpload.js
+++ b/src/components/Forms/DocumentUpload.js
@@ -70,10 +70,10 @@ export default function DocumentUpload({ onSuccess, onCancel }) {
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       <div>
-        <div className="mt-1 flex justify-center px-6 pt-5 pb-6 border-2 border-slate-700 border-dashed rounded-md bg-slate-900">
+        <div className="mt-1 flex justify-center px-6 pt-5 pb-6 border-2 border-slate-700 border-dashed rounded-md bg-slate-900 text-slate-100">
           <div className="space-y-1 text-center">
             <svg
-              className="mx-auto h-12 w-12 text-slate-400"
+              className="mx-auto h-12 w-12 text-slate-300"
               stroke="currentColor"
               fill="none"
               viewBox="0 0 48 48"
@@ -86,7 +86,7 @@ export default function DocumentUpload({ onSuccess, onCancel }) {
                 strokeLinejoin="round"
               />
             </svg>
-            <div className="flex text-sm text-slate-400">
+            <div className="flex text-sm text-slate-100">
               <label
                 htmlFor="file-upload"
                 className="relative cursor-pointer bg-transparent rounded-md font-medium text-sky-400 hover:text-sky-500 focus-within:outline-none focus-within:ring-2 focus-within:ring-sky-400 focus-within:ring-offset-0"
@@ -103,9 +103,9 @@ export default function DocumentUpload({ onSuccess, onCancel }) {
               </label>
               <p className="pl-1">or drag and drop</p>
             </div>
-            <p className="text-xs text-slate-400">PDF, JPG, PNG, DOCX up to 10MB</p>
+            <p className="text-xs text-slate-300">PDF, JPG, PNG, DOCX up to 10MB</p>
             {file && (
-              <p className="text-sm text-slate-50 truncate">
+              <p className="text-sm text-slate-100 truncate">
                 Selected: {file.name} ({(file.size / 1024 / 1024).toFixed(2)} MB)
               </p>
             )}
@@ -114,7 +114,7 @@ export default function DocumentUpload({ onSuccess, onCancel }) {
       </div>
 
       <div>
-        <label htmlFor="title" className="block text-sm font-medium text-slate-400">
+        <label htmlFor="title" className="block text-sm font-medium text-slate-300">
           Title
         </label>
         <input
@@ -122,7 +122,7 @@ export default function DocumentUpload({ onSuccess, onCancel }) {
           id="title"
           value={title}
           onChange={(e) => setTitle(e.target.value)}
-          className="mt-1 block w-full rounded-md bg-slate-900 border border-slate-700 text-slate-50 placeholder-slate-400 shadow-sm focus:border-sky-400 focus:ring-sky-400 sm:text-sm"
+          className="mt-1 block w-full rounded-md bg-slate-900 text-slate-100 placeholder-slate-500 border border-slate-700 shadow-sm focus:border-sky-400 sm:text-sm"
           placeholder="Enter a title for this document"
           required
         />

--- a/src/components/Forms/TransactionForm.js
+++ b/src/components/Forms/TransactionForm.js
@@ -106,7 +106,7 @@ export default function TransactionForm({ initialData = {}, onSuccess, onCancel 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       <div>
-        <label htmlFor="type" className="block text-sm font-medium text-slate-400">
+        <label htmlFor="type" className="block text-sm font-medium text-slate-300">
           Transaction Type
         </label>
         <select
@@ -114,7 +114,7 @@ export default function TransactionForm({ initialData = {}, onSuccess, onCancel 
           name="type"
           value={formData.type}
           onChange={handleChange}
-          className="mt-1 block w-full rounded-md bg-slate-900 border border-slate-700 text-slate-50 py-2 pl-3 pr-10 text-base focus:border-sky-400 focus:outline-none focus:ring-sky-400 sm:text-sm"
+          className="mt-1 block w-full rounded-md bg-slate-900 text-slate-100 placeholder-slate-500 border border-slate-700 py-2 pl-3 pr-10 text-base focus:border-sky-400 sm:text-sm"
           required
         >
           {transactionTypes.map((type) => (
@@ -126,7 +126,7 @@ export default function TransactionForm({ initialData = {}, onSuccess, onCancel 
       </div>
 
       <div>
-        <label htmlFor="account" className="block text-sm font-medium text-slate-400">
+        <label htmlFor="account" className="block text-sm font-medium text-slate-300">
           Account
         </label>
         <select
@@ -134,7 +134,7 @@ export default function TransactionForm({ initialData = {}, onSuccess, onCancel 
           name="account"
           value={formData.account}
           onChange={handleChange}
-          className="mt-1 block w-full rounded-md bg-slate-900 border border-slate-700 text-slate-50 py-2 pl-3 pr-10 text-base focus:border-sky-400 focus:outline-none focus:ring-sky-400 sm:text-sm"
+          className="mt-1 block w-full rounded-md bg-slate-900 text-slate-100 placeholder-slate-500 border border-slate-700 py-2 pl-3 pr-10 text-base focus:border-sky-400 sm:text-sm"
           required
         >
           {accounts.map((account) => (
@@ -146,12 +146,12 @@ export default function TransactionForm({ initialData = {}, onSuccess, onCancel 
       </div>
 
       <div>
-        <label htmlFor="amount" className="block text-sm font-medium text-slate-400">
+        <label htmlFor="amount" className="block text-sm font-medium text-slate-300">
           Amount
         </label>
         <div className="mt-1 relative rounded-md shadow-sm">
           <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-            <span className="text-slate-400 sm:text-sm">
+            <span className="text-slate-300 sm:text-sm">
               {formData.type === 'expense' ? '-' : '+'} ₹
             </span>
           </div>
@@ -163,14 +163,14 @@ export default function TransactionForm({ initialData = {}, onSuccess, onCancel 
             name="amount"
             value={formData.amount}
             onChange={handleChange}
-            className="pl-12 block w-full rounded-md bg-slate-900 border border-slate-700 text-slate-50 placeholder-slate-400 shadow-sm focus:border-sky-400 focus:ring-sky-400 sm:text-sm"
+            className="pl-12 block w-full rounded-md bg-slate-900 text-slate-100 placeholder-slate-500 border border-slate-700 shadow-sm focus:border-sky-400 sm:text-sm"
             required
           />
         </div>
       </div>
 
       <div>
-        <label htmlFor="category" className="block text-sm font-medium text-slate-400">
+        <label htmlFor="category" className="block text-sm font-medium text-slate-300">
           Category
         </label>
         <select
@@ -178,7 +178,7 @@ export default function TransactionForm({ initialData = {}, onSuccess, onCancel 
           name="category"
           value={formData.category}
           onChange={handleChange}
-          className="mt-1 block w-full rounded-md bg-slate-900 border border-slate-700 text-slate-50 py-2 pl-3 pr-10 text-base focus:border-sky-400 focus:outline-none focus:ring-sky-400 sm:text-sm"
+          className="mt-1 block w-full rounded-md bg-slate-900 text-slate-100 placeholder-slate-500 border border-slate-700 py-2 pl-3 pr-10 text-base focus:border-sky-400 sm:text-sm"
           required
         >
           <option value="">Select a category</option>
@@ -191,7 +191,7 @@ export default function TransactionForm({ initialData = {}, onSuccess, onCancel 
       </div>
 
       <div>
-        <label htmlFor="happened_on" className="block text-sm font-medium text-slate-400">
+        <label htmlFor="happened_on" className="block text-sm font-medium text-slate-300">
           Date & Time
         </label>
         <input
@@ -200,13 +200,13 @@ export default function TransactionForm({ initialData = {}, onSuccess, onCancel 
           name="happened_on"
           value={formData.happened_on}
           onChange={handleChange}
-          className="mt-1 block w-full rounded-md bg-slate-900 border border-slate-700 text-slate-50 placeholder-slate-400 shadow-sm focus:border-sky-400 focus:ring-sky-400 sm:text-sm"
+          className="mt-1 block w-full rounded-md bg-slate-900 text-slate-100 placeholder-slate-500 border border-slate-700 shadow-sm focus:border-sky-400 sm:text-sm"
           required
         />
       </div>
 
       <div>
-        <label htmlFor="note" className="block text-sm font-medium text-slate-400">
+        <label htmlFor="note" className="block text-sm font-medium text-slate-300">
           Note (Optional)
         </label>
         <textarea
@@ -215,7 +215,7 @@ export default function TransactionForm({ initialData = {}, onSuccess, onCancel 
           rows={3}
           value={formData.note}
           onChange={handleChange}
-          className="mt-1 block w-full rounded-md bg-slate-900 border border-slate-700 text-slate-50 placeholder-slate-400 shadow-sm focus:border-sky-400 focus:ring-sky-400 sm:text-sm"
+          className="mt-1 block w-full rounded-md bg-slate-900 text-slate-100 placeholder-slate-500 border border-slate-700 shadow-sm focus:border-sky-400 sm:text-sm"
         />
       </div>
 

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,75 +1,49 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
+import { createPortal } from 'react-dom';
 
-export default function Modal({ isOpen, onClose, title, children, footer }) {
-  const modalRef = useRef(null);
-
+export default function Modal({ open, onClose, title, children }) {
   useEffect(() => {
-    const handleEscape = (e) => {
-      if (e.key === 'Escape') {
-        onClose();
-      }
+    if (!open) return;
+    const handleEsc = (e) => {
+      if (e.key === 'Escape') onClose();
     };
-
-    const handleClickOutside = (e) => {
-      if (modalRef.current && !modalRef.current.contains(e.target)) {
-        onClose();
-      }
-    };
-
-    if (isOpen) {
-      document.addEventListener('keydown', handleEscape);
-      document.addEventListener('mousedown', handleClickOutside);
-      document.body.style.overflow = 'hidden';
-    }
-
+    document.addEventListener('keydown', handleEsc);
+    document.body.style.overflow = 'hidden';
     return () => {
-      document.removeEventListener('keydown', handleEscape);
-      document.removeEventListener('mousedown', handleClickOutside);
-      document.body.style.overflow = 'auto';
+      document.removeEventListener('keydown', handleEsc);
+      document.body.style.overflow = '';
     };
-  }, [isOpen, onClose]);
+  }, [open, onClose]);
 
-  if (!isOpen) return null;
+  if (!open) return null;
 
-  return (
-    <div className="fixed inset-0 z-50 overflow-y-auto">
-      <div className="flex min-h-screen items-center justify-center px-4 pt-4 pb-20 text-center sm:block sm:p-0">
-        <div className="fixed inset-0 transition-opacity" aria-hidden="true">
-          <div className="absolute inset-0 bg-slate-900/80"></div>
-        </div>
-
-        <span className="hidden sm:inline-block sm:h-screen sm:align-middle" aria-hidden="true">
-          &#8203;
-        </span>
-
+  return createPortal(
+    <>
+      <div
+        className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      <div
+        className="fixed inset-0 z-50 grid place-items-center p-4"
+        onClick={onClose}
+      >
         <div
-          ref={modalRef}
-          className="inline-block transform overflow-hidden rounded-xl bg-slate-800 text-left align-bottom shadow-xl border border-slate-700 transition-all sm:my-8 sm:w-full sm:max-w-lg sm:align-middle text-slate-50"
+          onClick={(e) => e.stopPropagation()}
           role="dialog"
           aria-modal="true"
-          aria-labelledby="modal-headline"
+          className="z-[60] w-full max-w-2xl rounded-xl bg-slate-800/95 shadow-xl ring-1 ring-slate-700 text-slate-100"
         >
-          <div className="bg-slate-800 px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
-            <div className="sm:flex sm:items-start">
-              <div className="mt-3 w-full text-center sm:mt-0 sm:ml-4 sm:text-left">
-                {title && (
-                  <h3 className="text-lg font-medium leading-6 text-slate-50" id="modal-headline">
-                    {title}
-                  </h3>
-                )}
-                <div className="mt-4">{children}</div>
-              </div>
-            </div>
-          </div>
-          {footer && (
-            <div className="bg-slate-800 border-t border-slate-700 px-4 py-3 sm:flex sm:flex-row-reverse sm:px-6">
-              {footer}
+          {title && (
+            <div className="px-6 pt-4 pb-2">
+              <h2 className="text-lg font-medium text-slate-100">{title}</h2>
             </div>
           )}
+          <div className="px-6 pb-6">{children}</div>
         </div>
       </div>
-    </div>
+    </>,
+    document.body
   );
 }


### PR DESCRIPTION
## Summary
- standardize Modal with z-index layering, backdrop blur, and esc-to-close behavior
- replace Add Transaction navigation with state-driven modal button
- update Account & Document pages to use new Modal API and non-navigating buttons
- restyle form inputs for high-contrast appearance inside modals

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6897b98bf9d0832193d7104cc6676cc9