### PR TITLE
fix: allow account alias for transactions

### DIFF
--- a/src/app/api/transactions/route.js
+++ b/src/app/api/transactions/route.js
@@ -64,9 +64,14 @@ export async function POST(req) {
   const requestId = Math.random().toString(36).substring(2, 9);
   
   console.log(`[API] [${requestId}] POST /api/transactions - Starting`);
-  
+
   const raw = await req.json();
-  const { error, value } = transactionSchema.validate(raw, { abortEarly: false });
+  const body = { ...raw };
+  if (body.account && !body.account_id) {
+    body.account_id = body.account;
+    delete body.account;
+  }
+  const { error, value } = transactionSchema.validate(body, { abortEarly: false });
   
   if (error) {
     console.error(`[API] [${requestId}] POST /api/transactions - Validation failed (${Date.now() - startTime}ms):`, error.message);
@@ -145,9 +150,13 @@ export async function PUT(req) {
   const requestId = Math.random().toString(36).substring(2, 9);
   
   console.log(`[API] [${requestId}] PUT /api/transactions - Starting`);
-  
+
   try {
     const body = await req.json();
+    if (body.account && !body.account_id) {
+      body.account_id = body.account;
+      delete body.account;
+    }
     const { _id, account_id, type, amount, currency, category, note, tags, happened_on, attachment_ids } = body || {};
     if (!_id) return new Response(errorObject("_id is required", 400), { status: 400 });
 


### PR DESCRIPTION
## Summary
- map legacy `account` field to `account_id` in transaction POST/PUT handlers
- restore transaction schema without alias renaming

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898481537008321ad1d3b7e75665caf