### PR TITLE
feat: add Personal Hub dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added shared S3 helper with presign and delete utilities.
 - Updated client fetcher, components, and pages to follow `/api` conventions and refresh data after mutations.
 - Marked shared UI components as client components.
+- Introduced Personal Hub dashboard with stats cards, charts, and lists.
 
 ## Known TODOs
 - Support transaction transfers between accounts.

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "next": "15.4.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "recharts": "^2.12.2",
         "tailwind-merge": "^3.3.1"
       },
       "devDependencies": {
@@ -901,6 +902,15 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
+      "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2784,6 +2794,69 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
+      "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -3879,8 +3952,128 @@
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -3961,6 +4154,12 @@
         }
       }
     },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4020,6 +4219,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
       }
     },
     "node_modules/dunder-proto": {
@@ -4649,11 +4858,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
+    },
+    "node_modules/fast-equals": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.2.2.tgz",
+      "integrity": "sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.1",
@@ -5098,6 +5322,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -5537,8 +5770,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -5923,6 +6155,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -5975,7 +6213,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -6264,7 +6501,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6542,7 +6778,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -6599,8 +6834,76 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -7254,6 +7557,12 @@
         "node": ">=18"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
@@ -7524,6 +7833,28 @@
       ],
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "next": "15.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "recharts": "^2.12.2",
     "tailwind-merge": "^3.3.1"
   },
   "devDependencies": {

--- a/src/app/dashboard/_adapters.js
+++ b/src/app/dashboard/_adapters.js
@@ -1,0 +1,88 @@
+/**
+ * Pure functions to adapt API responses into UI friendly shapes.
+ * All transformers below accept raw API JSON and return
+ * simplified objects expected by the dashboard components.
+ */
+
+/**
+ * Adapts overview metrics.
+ * @param {Object} api Raw metrics from various endpoints
+ * @returns {{netWorth:{amount:number,deltaPct:number}, totalAccounts:number, monthlyExpenses:{amount:number,deltaPct:number}, txCountThisMonth:number}}
+ */
+export function adaptOverview(api = {}) {
+  const net = api.netWorth || {};
+  const netCurr = Number(net.current) || 0;
+  const netPrev = Number(net.previous) || 0;
+  const netDelta = netPrev ? ((netCurr - netPrev) / netPrev) * 100 : 0;
+
+  const exp = api.monthlyExpenses || {};
+  const expCurr = Number(exp.current) || 0;
+  const expPrev = Number(exp.previous) || 0;
+  const expDelta = expPrev ? ((expCurr - expPrev) / expPrev) * 100 : 0;
+
+  return {
+    netWorth: { amount: netCurr, deltaPct: netDelta },
+    totalAccounts: Number(api.totalAccounts) || 0,
+    monthlyExpenses: { amount: expCurr, deltaPct: expDelta },
+    txCountThisMonth: Number(api.txCountThisMonth) || 0,
+  };
+}
+
+/**
+ * Adapts net worth series data for the line chart.
+ * @param {Array} api Array of { month: 'YYYY-MM', networth: number }
+ * @returns {Array} Array of { label: 'Jan', value: number }
+ */
+export function adaptNetWorthSeries(api = []) {
+  if (!Array.isArray(api)) return [];
+  return api.map((item) => {
+    const date = item.month ? new Date(`${item.month}-01`) : new Date();
+    const label = date.toLocaleString('en-IN', { month: 'short' });
+    return { label, value: Number(item.networth || item.value) || 0 };
+  });
+}
+
+/**
+ * Adapts expense breakdown data for the donut chart.
+ * @param {Array} api Array of { category: string, amount: number }
+ * @returns {Array} Array of { label: string, value: number }
+ */
+export function adaptExpenseBreakdown(api = []) {
+  if (!Array.isArray(api)) return [];
+  return api.map((item) => ({
+    label: item.category || item.label,
+    value: Number(item.amount || item.value) || 0,
+  }));
+}
+
+/**
+ * Adapts accounts list data.
+ * @param {Array} api Raw accounts array
+ * @returns {Array} Array of { name:string, balance:number, currency:string, trend:'up'|'down' }
+ */
+export function adaptAccounts(api = []) {
+  if (!Array.isArray(api)) return [];
+  return api.map((acc) => ({
+    name: acc.name,
+    balance: Number(acc.balance) || 0,
+    currency: acc.currency || 'INR',
+    trend: (Number(acc.balance) || 0) >= 0 ? 'up' : 'down',
+  }));
+}
+
+/**
+ * Adapts recent transactions list.
+ * @param {Array} api Raw transactions array
+ * @returns {Array} Array of { date:string, description:string, category:string, amount:number, currency:string }
+ */
+export function adaptRecentTx(api = []) {
+  if (!Array.isArray(api)) return [];
+  return api.map((tx) => ({
+    date: tx.created_on || tx.date,
+    description: tx.note || tx.description || tx.category,
+    category: tx.category,
+    amount: tx.type === 'expense' ? -Number(tx.amount) : Number(tx.amount),
+    currency: tx.currency || 'INR',
+  }));
+}
+

--- a/src/app/dashboard/page.js
+++ b/src/app/dashboard/page.js
@@ -1,1 +1,142 @@
-export { default } from '../page';
+import dynamic from 'next/dynamic';
+import dayjs from 'dayjs';
+import PageHeader from '@/components/PageHeader';
+import AddTransactionButton from '@/components/AddTransactionButton';
+import Card from '@/components/Card';
+import StatsCard from '@/components/dashboard/StatsCard';
+import AccountsList from '@/components/accounts/AccountsList';
+import RecentTable from '@/components/transactions/RecentTable';
+import ProtectedRoute from '@/components/ProtectedRoute';
+import { monthParam, formatINR } from '@/lib/format';
+import {
+  adaptOverview,
+  adaptNetWorthSeries,
+  adaptExpenseBreakdown,
+  adaptAccounts,
+  adaptRecentTx,
+} from './_adapters';
+
+const NetWorthLine = dynamic(() => import('@/components/charts/NetWorthLine'), { ssr: false });
+const ExpenseDonut = dynamic(() => import('@/components/charts/ExpenseDonut'), { ssr: false });
+
+// Server component page that fetches dashboard data
+export default async function Page() {
+  const months = Array.from({ length: 6 }, (_, i) => dayjs().subtract(i, 'month'));
+  const monthKeys = months.map((m) => monthParam(m));
+
+  const fetchJson = async (url) => {
+    try {
+      const res = await fetch(url, { cache: 'no-store' });
+      return await res.json();
+    } catch (e) {
+      console.error('Fetch failed', url, e);
+      return null;
+    }
+  };
+
+  const [netWorthApi, accountsApi, recentTxApi, ...monthApis] = await Promise.all([
+    fetchJson('/api/metrics/networth'),
+    fetchJson('/api/accounts'),
+    fetchJson('/api/transactions?limit=5&sort=created_on'),
+    ...monthKeys.map((m) => fetchJson(`/api/transactions?month=${m}`)),
+  ]);
+
+  const monthTx = monthApis.map((m) => (m && m.data ? m.data : []));
+  const monthStats = monthTx.map((tx) => {
+    let income = 0;
+    let expense = 0;
+    tx.forEach((t) => {
+      if (t.type === 'income') income += t.amount;
+      else if (t.type === 'expense') expense += t.amount;
+    });
+    return { income, expense, net: income - expense };
+  });
+
+  const netWorthCurrent = netWorthApi?.data?.networth || 0;
+  const prevNetWorth = netWorthCurrent - (monthStats[0]?.net || 0);
+
+  const overviewRaw = {
+    netWorth: { current: netWorthCurrent, previous: prevNetWorth },
+    totalAccounts: accountsApi?.data?.length || 0,
+    monthlyExpenses: {
+      current: monthStats[0]?.expense || 0,
+      previous: monthStats[1]?.expense || 0,
+    },
+    txCountThisMonth: monthTx[0]?.length || 0,
+  };
+  const overview = adaptOverview(overviewRaw);
+
+  let running = netWorthCurrent;
+  const netSeriesRaw = [];
+  for (let i = 0; i < monthStats.length; i++) {
+    netSeriesRaw.unshift({ month: monthKeys[i], networth: running });
+    running -= monthStats[i]?.net || 0;
+  }
+  const netSeries = adaptNetWorthSeries(netSeriesRaw);
+
+  const expenseRaw = Object.entries(
+    monthTx[0]
+      ?.filter((t) => t.type === 'expense')
+      .reduce((acc, t) => {
+        acc[t.category] = (acc[t.category] || 0) + t.amount;
+        return acc;
+      }, {}) || {}
+  ).map(([category, amount]) => ({ category, amount }));
+  const expenseBreakdown = adaptExpenseBreakdown(expenseRaw);
+
+  const accounts = adaptAccounts(accountsApi?.data || []);
+  const recent = adaptRecentTx(recentTxApi?.data || []);
+
+  return (
+    <ProtectedRoute>
+      <div>
+        <PageHeader title="Personal Hub" actions={<AddTransactionButton />} />
+        <p className="text-sm text-slate-400 mb-6">Welcome back! Here&apos;s your financial overview</p>
+
+        <div className="grid gap-4 mb-8 sm:grid-cols-2 lg:grid-cols-4">
+          <StatsCard
+            title="Net Worth"
+            value={formatINR(overview.netWorth.amount)}
+            deltaPct={overview.netWorth.deltaPct}
+          />
+          <StatsCard title="Total Accounts" value={overview.totalAccounts} />
+          <StatsCard
+            title="Monthly Expenses"
+            value={formatINR(overview.monthlyExpenses.amount)}
+            deltaPct={overview.monthlyExpenses.deltaPct}
+            valueClass="text-orange-400"
+            deltaColor="text-orange-400"
+          />
+          <StatsCard
+            title="Transactions"
+            value={overview.txCountThisMonth}
+            subtitle="This month"
+          />
+        </div>
+
+        <div className="grid gap-4 mb-8 md:grid-cols-2">
+          <Card>
+            <h3 className="mb-4 text-lg font-medium text-slate-50">Net Worth Trend</h3>
+            <NetWorthLine data={netSeries} />
+          </Card>
+          <Card>
+            <h3 className="mb-4 text-lg font-medium text-slate-50">Expense Breakdown</h3>
+            <ExpenseDonut data={expenseBreakdown} />
+          </Card>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <Card>
+            <h3 className="mb-4 text-lg font-medium text-slate-50">Accounts</h3>
+            <AccountsList accounts={accounts} />
+          </Card>
+          <Card>
+            <h3 className="mb-4 text-lg font-medium text-slate-50">Recent Transactions</h3>
+            <RecentTable transactions={recent} />
+          </Card>
+        </div>
+      </div>
+    </ProtectedRoute>
+  );
+}
+

--- a/src/components/accounts/AccountsList.js
+++ b/src/components/accounts/AccountsList.js
@@ -1,0 +1,45 @@
+import { formatINR } from '@/lib/format';
+
+// Compact list of accounts with balance and trend arrow
+export default function AccountsList({ accounts }) {
+  if (!accounts || accounts.length === 0) {
+    return <p className="text-sm text-slate-400 text-center py-4">No records found</p>;
+  }
+
+  return (
+    <ul className="divide-y divide-slate-700">
+      {accounts.map((acc, idx) => (
+        <li key={idx} className="flex items-center justify-between py-3">
+          <span className="text-sm text-slate-50">{acc.name}</span>
+          <span className="flex items-center text-sm">
+            {formatINR(acc.balance)}
+            {acc.trend === 'up' ? (
+              <UpIcon className="w-4 h-4 ml-1 text-green-500" />
+            ) : (
+              <DownIcon className="w-4 h-4 ml-1 text-red-500" />
+            )}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function UpIcon(props) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M5 10l7-7 7 7" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v18" />
+    </svg>
+  );
+}
+
+function DownIcon(props) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M19 14l-7 7-7-7" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 21V3" />
+    </svg>
+  );
+}
+

--- a/src/components/charts/ExpenseDonut.js
+++ b/src/components/charts/ExpenseDonut.js
@@ -1,0 +1,33 @@
+"use client";
+
+import { PieChart, Pie, Tooltip, Cell, ResponsiveContainer } from 'recharts';
+
+const COLORS = ['#6366f1', '#f59e0b', '#10b981', '#ef4444', '#14b8a6', '#e879f9'];
+
+// Donut chart for expense category breakdown
+export default function ExpenseDonut({ data }) {
+  if (!data || data.length === 0) {
+    return <p className="text-sm text-slate-400 text-center">No data available</p>;
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={260}>
+      <PieChart>
+        <Pie
+          data={data}
+          dataKey="value"
+          nameKey="label"
+          innerRadius={60}
+          outerRadius={100}
+          paddingAngle={2}
+        >
+          {data.map((entry, index) => (
+            <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+          ))}
+        </Pie>
+        <Tooltip contentStyle={{ backgroundColor: '#1e293b', border: 'none' }} />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}
+

--- a/src/components/charts/NetWorthLine.js
+++ b/src/components/charts/NetWorthLine.js
@@ -1,0 +1,22 @@
+"use client";
+
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+
+// Line chart showing net worth over months
+export default function NetWorthLine({ data }) {
+  if (!data || data.length === 0) {
+    return <p className="text-sm text-slate-400 text-center">No data available</p>;
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={260}>
+      <LineChart data={data} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
+        <XAxis dataKey="label" stroke="#94a3b8" tickLine={false} axisLine={false} />
+        <YAxis stroke="#94a3b8" tickLine={false} axisLine={false} />
+        <Tooltip contentStyle={{ backgroundColor: '#1e293b', border: 'none' }} />
+        <Line type="monotone" dataKey="value" stroke="#10b981" strokeWidth={2} dot={false} />
+      </LineChart>
+    </ResponsiveContainer>
+  );
+}
+

--- a/src/components/dashboard/StatsCard.js
+++ b/src/components/dashboard/StatsCard.js
@@ -1,0 +1,44 @@
+/**
+ * Small metric card for dashboard stats.
+ * Expects pre-formatted value strings.
+ */
+export default function StatsCard({ title, value, deltaPct, valueClass = '', deltaColor, subtitle }) {
+  const delta = typeof deltaPct === 'number' ? deltaPct : null;
+  const DeltaIcon = delta !== null && delta < 0 ? DownIcon : UpIcon;
+  const deltaCls = deltaColor || (delta !== null && delta < 0 ? 'text-red-500' : 'text-green-500');
+
+  return (
+    <div className="bg-slate-800 rounded-2xl shadow-sm border border-slate-700 p-4">
+      <p className="text-sm text-slate-400">{title}</p>
+      <div className="mt-2 flex items-end justify-between">
+        <span className={`text-2xl font-semibold text-slate-50 ${valueClass}`}>{value}</span>
+        {delta !== null && (
+          <span className={`flex items-center text-sm ${deltaCls}`}>
+            <DeltaIcon className="w-4 h-4 mr-1" />
+            {Math.abs(delta).toFixed(1)}%
+          </span>
+        )}
+      </div>
+      {subtitle && <p className="mt-1 text-xs text-slate-400">{subtitle}</p>}
+    </div>
+  );
+}
+
+function UpIcon(props) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M5 10l7-7 7 7" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 3v18" />
+    </svg>
+  );
+}
+
+function DownIcon(props) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" {...props}>
+      <path strokeLinecap="round" strokeLinejoin="round" d="M19 14l-7 7-7-7" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M12 21V3" />
+    </svg>
+  );
+}
+

--- a/src/components/transactions/RecentTable.js
+++ b/src/components/transactions/RecentTable.js
@@ -1,0 +1,25 @@
+"use client";
+
+import Table from '@/components/Table';
+import { formatINR, formatDateShort } from '@/lib/format';
+
+// Table of recent transactions
+export default function RecentTable({ transactions }) {
+  const columns = [
+    { key: 'date', header: 'Date', render: (tx) => formatDateShort(tx.date) },
+    { key: 'description', header: 'Description' },
+    { key: 'category', header: 'Category' },
+    {
+      key: 'amount',
+      header: 'Amount',
+      render: (tx) => (
+        <span className={tx.amount < 0 ? 'text-red-500' : 'text-green-500'}>
+          {formatINR(tx.amount)}
+        </span>
+      ),
+    },
+  ];
+
+  return <Table columns={columns} data={transactions || []} emptyState="No records found" />;
+}
+


### PR DESCRIPTION
## Summary
- implement Personal Hub dashboard with server-side data fetching
- add charts, stats cards, accounts list and recent transactions table
- create data adapters and integrate Recharts

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68998f5ca8c083218e01fb449c52d3e3